### PR TITLE
Document get all

### DIFF
--- a/mcdbctl.c
+++ b/mcdbctl.c
@@ -536,10 +536,10 @@ static const char * const restrict mcdb_usage =
    "         mcdbctl uniq  <fname.mcdb> [\"first\"|\"last\"]\n"
    "         mcdbctl dump  <fname.mcdb>\n"
    "         mcdbctl stats <fname.mcdb>\n"
-   "         mcdbctl get   <fname.mcdb> <key> [seq]\n";
+   "         mcdbctl get   <fname.mcdb> <key> [seq|\"all\"]\n";
 
 /*
- * mcdbctl get   <mcdb> <key> [seq]
+ * mcdbctl get   <mcdb> <key> [seq|"all"]
  * mcdbctl dump  <mcdb>
  * mcdbctl stats <mcdb>
  * mcdbctl make  <mcdb> <input-file>


### PR DESCRIPTION
You wouldn't know about `mcdbctl get file.db key all` unless you read the source code.

I came across code that executed `mcdbctl get file.db key 1`, `mcdbctl get file.db key 2`, etc. until it got an error to retrieve all values for a key. Hence this pull request.
