### PR TITLE
Replaced `cp` with `install` in Makefile for compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,16 +316,16 @@ install-plasma-headers: plasma/plasma_attr.h \
                         plasma/plasma_stdtypes.h
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/include/mcdb/plasma
 	umask 333; \
-	  /usr/bin/install $^ $(PREFIX_USR)/include/mcdb/plasma/
+	  /usr/bin/install -p $^ $(PREFIX_USR)/include/mcdb/plasma/
 install-headers: mcdb.h mcdb_error.h mcdb_make.h mcdb_makefmt.h mcdb_makefn.h \
                  | install-plasma-headers
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/include/mcdb
 	umask 333; \
-	  /usr/bin/install $^ $(PREFIX_USR)/include/mcdb/
+	  /usr/bin/install -p $^ $(PREFIX_USR)/include/mcdb/
 install-doc: CHANGELOG COPYING FAQ INSTALL NOTES README
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/share/doc/mcdb
 	umask 333; \
-	  /usr/bin/install $^ $(PREFIX_USR)/share/doc/mcdb
+	  /usr/bin/install -p $^ $(PREFIX_USR)/share/doc/mcdb
 install: $(PREFIX)/lib$(LIB_BITS)/libnss_mcdb.so.2 \
          $(PREFIX_USR)/lib$(LIB_BITS)/libnss_mcdb.so.2 \
          $(PREFIX_USR)/lib$(LIB_BITS)/libmcdb.so \

--- a/Makefile
+++ b/Makefile
@@ -316,16 +316,16 @@ install-plasma-headers: plasma/plasma_attr.h \
                         plasma/plasma_stdtypes.h
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/include/mcdb/plasma
 	umask 333; \
-	  /bin/cp -f --preserve=timestamps $^ $(PREFIX_USR)/include/mcdb/plasma/
+	  /usr/bin/install $^ $(PREFIX_USR)/include/mcdb/plasma/
 install-headers: mcdb.h mcdb_error.h mcdb_make.h mcdb_makefmt.h mcdb_makefn.h \
                  | install-plasma-headers
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/include/mcdb
 	umask 333; \
-	  /bin/cp -f --preserve=timestamps $^ $(PREFIX_USR)/include/mcdb/
+	  /usr/bin/install $^ $(PREFIX_USR)/include/mcdb/
 install-doc: CHANGELOG COPYING FAQ INSTALL NOTES README
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/share/doc/mcdb
 	umask 333; \
-	  /bin/cp -f --preserve=timestamps $^ $(PREFIX_USR)/share/doc/mcdb
+	  /usr/bin/install $^ $(PREFIX_USR)/share/doc/mcdb
 install: $(PREFIX)/lib$(LIB_BITS)/libnss_mcdb.so.2 \
          $(PREFIX_USR)/lib$(LIB_BITS)/libnss_mcdb.so.2 \
          $(PREFIX_USR)/lib$(LIB_BITS)/libmcdb.so \

--- a/Makefile
+++ b/Makefile
@@ -316,16 +316,16 @@ install-plasma-headers: plasma/plasma_attr.h \
                         plasma/plasma_stdtypes.h
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/include/mcdb/plasma
 	umask 333; \
-	  /usr/bin/install -p $^ $(PREFIX_USR)/include/mcdb/plasma/
+	  /usr/bin/install -p -m 0444 $^ $(PREFIX_USR)/include/mcdb/plasma/
 install-headers: mcdb.h mcdb_error.h mcdb_make.h mcdb_makefmt.h mcdb_makefn.h \
                  | install-plasma-headers
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/include/mcdb
 	umask 333; \
-	  /usr/bin/install -p $^ $(PREFIX_USR)/include/mcdb/
+	  /usr/bin/install -p -m 0444 $^ $(PREFIX_USR)/include/mcdb/
 install-doc: CHANGELOG COPYING FAQ INSTALL NOTES README
 	/bin/mkdir -p -m 0755 $(PREFIX_USR)/share/doc/mcdb
 	umask 333; \
-	  /usr/bin/install -p $^ $(PREFIX_USR)/share/doc/mcdb
+	  /usr/bin/install -p -m 0444 $^ $(PREFIX_USR)/share/doc/mcdb
 install: $(PREFIX)/lib$(LIB_BITS)/libnss_mcdb.so.2 \
          $(PREFIX_USR)/lib$(LIB_BITS)/libnss_mcdb.so.2 \
          $(PREFIX_USR)/lib$(LIB_BITS)/libmcdb.so \


### PR DESCRIPTION
Replaced `cp` with `install` in Makefile for compatibility with non-GNU systems: Mac OS X, for example, doesn't have GNU cp, and its `cp` command doesn't support `--preserve`. I believe using `install` will be more portable that `cp --preserve` (systems that have GNU cp probably have `install` as well).